### PR TITLE
add Spring Cloud config server dependencies to pom

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectRequest.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectRequest.java
@@ -16,23 +16,18 @@
 
 package io.spring.initializr.generator;
 
+import io.spring.initializr.metadata.*;
+import io.spring.initializr.util.Version;
+import io.spring.initializr.util.VersionProperty;
+import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.util.StringUtils;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import io.spring.initializr.metadata.BillOfMaterials;
-import io.spring.initializr.metadata.DefaultMetadataElement;
-import io.spring.initializr.metadata.Dependency;
-import io.spring.initializr.metadata.InitializrMetadata;
-import io.spring.initializr.metadata.Repository;
-import io.spring.initializr.metadata.Type;
-import io.spring.initializr.util.Version;
-import io.spring.initializr.util.VersionProperty;
-
-import org.springframework.beans.BeanWrapperImpl;
-import org.springframework.util.StringUtils;
 
 /**
  * A request to generate a project.
@@ -68,6 +63,13 @@ public class ProjectRequest extends BasicProjectRequest {
 
 	public void setResolvedDependencies(List<Dependency> resolvedDependencies) {
 		this.resolvedDependencies = resolvedDependencies;
+	}
+
+	public void removeDependency(String id) {
+		if (this.resolvedDependencies != null) {
+			Predicate<Dependency> filter = d -> d.getId().equals(id);
+			this.resolvedDependencies.removeIf(filter);
+		}
 	}
 
 	public List<String> getFacets() {

--- a/initializr-service/src/main/java/io/spring/initializr/service/extension/SpringCloudConfigServerPostProcessor.java
+++ b/initializr-service/src/main/java/io/spring/initializr/service/extension/SpringCloudConfigServerPostProcessor.java
@@ -1,0 +1,32 @@
+package io.spring.initializr.service.extension;
+
+import io.spring.initializr.generator.ProjectRequest;
+import io.spring.initializr.metadata.Dependency;
+import io.spring.initializr.metadata.InitializrMetadata;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringCloudConfigServerPostProcessor extends AbstractProjectRequestPostProcessor {
+
+    private static final Dependency SPRING_BOOT_STARTER_WEB = Dependency.withId("spring-boot-starter-web",
+            "org.springframework.boot", "spring-boot-starter-web");
+
+    static final Dependency SPRING_CLOUD_CONFIG_SERVER = Dependency.withId(
+            "spring-cloud-config-server", "org.springframework.cloud",
+            "spring-cloud-config-server");
+
+    @Override
+    public void postProcessAfterResolution(ProjectRequest request,
+                                           InitializrMetadata metadata) {
+        if (!hasDependency(request, "spring-boot-starter-web")
+                && hasDependency(request, "azure-config-server")) {
+            request.getResolvedDependencies().add(SPRING_BOOT_STARTER_WEB);
+        }
+        if (!hasDependency(request, "spring-cloud-config-server")
+                && hasDependency(request, "azure-config-server")) {
+            request.getResolvedDependencies().add(SPRING_CLOUD_CONFIG_SERVER);
+        }
+        request.removeDependency("azure-config-server");
+    }
+
+}

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -1104,6 +1104,15 @@ initializr:
       bom: azure
       versionRange: "1.5.4.RELEASE"
       content:
+        - name: Azure Config Server
+          id: azure-config-server
+          groupId: com.microsoft.azure.configserver
+          artifactId: azure-config-server
+          description:
+          links:
+            - rel: reference
+              href: https://github.com/microsoft/spring-cloud-azure
+              description: Reference doc
         - name: Azure Support
           id: azure-support
           groupId: com.microsoft.azure


### PR DESCRIPTION
when use ticked "Azure Config Server", two required dependencies will be added to pom.xml. Previously only one dependency can be added to pom.xml when something is choosen in initializr.