### PR TITLE
Remove unnecessary expose and ports in docker compose, #42

### DIFF
--- a/initializr-generator/src/main/resources/templates/docker/docker-compose.yml
+++ b/initializr-generator/src/main/resources/templates/docker/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     image: "demo/cloud-config-server"
     ports:
       - "8888:8888"
-    expose:
-      - "8888"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://config-server:8888/gateway-server.yml"]
       interval: 5s
@@ -17,8 +15,6 @@ services:
     image: "demo/cloud-eureka-server"
     ports:
       - "8761:8761"
-    expose:
-      - "8761"
     links:
       - config-server
     depends_on:
@@ -34,8 +30,6 @@ services:
     image: "demo/azure-service-bus"
     ports:
       - "8081:8081"
-    expose:
-      - "8081"
     links:
       - eureka-server
       - config-server
@@ -52,8 +46,6 @@ services:
     image: "demo/cloud-hystrix-dashboard"
     ports:
       - "7979:7979"
-    expose:
-      - "7979"
     links:
       - eureka-server
       - config-server
@@ -64,10 +56,6 @@ services:
 {{#cloud-gateway}}
   gateway-server:
     image: "demo/cloud-gateway"
-    ports:
-      - "8080:8080"
-    expose:
-      - "8080"
     links:
       - eureka-server
       - config-server
@@ -79,4 +67,3 @@ services:
       interval: 5s
       retries: 20
 {{/cloud-gateway}}
-


### PR DESCRIPTION
* For now only config, register and dashboard ports outside.

Signed-off-by: Pan Li <panli@microsoft.com>